### PR TITLE
CI: Use `PR_TOKEN` secret to create PRs for update-niv

### DIFF
--- a/.github/workflows/update-niv.yml
+++ b/.github/workflows/update-niv.yml
@@ -20,3 +20,4 @@ jobs:
         commit-message: "[automation] update niv dependencies"
         title: "[automation] update niv dependencies"
         branch: "automation/update-niv-dependencies"
+        token: "${{ secrets.PR_TOKEN }}"


### PR DESCRIPTION
Using the automatic GITHUB_TOKEN prevents running workflows triggered by
actions directly.