### PR TITLE
Skip writing to the remote cache with no API key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,15 @@ jobs:
       env:
         BUILDBUDDY_API_KEY: '${{ secrets.BUILDBUDDY_API_KEY }}'
       run: |
+        if [ -z "$BUILDBUDDY_API_KEY" ]; then
+          cache_setting='build --noremote_upload_local_results'
+        else
+          cache_setting="build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+        fi
         cat > .bazelrc.local <<EOF
         startup --max_idle_secs=5
         common --config=ci
-        build --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
+        $cache_setting
         EOF
         cat > ~/.netrc <<EOF
         machine api.github.com


### PR DESCRIPTION
For foreign PRs (e.g. dependabot) access to the repository secrets is not permitted,
so the API key for Buildbuddy ends up empty.

This leads to an error later:
```
WARNING: BES was not properly closed
ERROR: The Build Event Protocol upload failed: Not retrying publishBuildEvents, no more attempts left: status='Status{code=UNAUTHENTICATED, description=failed to parse API key: missing API Key, cause=null}' UNAUTHENTICATED: UNAUTHENTICATED: failed to parse API key: missing API Key UNAUTHENTICATED: UNAUTHENTICATED: failed to parse API key: missing API Key
```