### PR TITLE
CI: Update bazel-central-registry for renovate PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,12 @@ jobs:
         # Only needed for private caches
         #authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix flake check
+    - name: Set author identity
+      run: |
+        git config user.email '${{ github.actor }}@users.noreply.github.com'
+        git config user.name '${{ github.actor }}'
+    - run: nix flake lock --update-input bazel-central-registry --commit-lock-file
+      if: github.event.pull_request.user.login == 'renovate[bot]' && github.repository == 'avdv/scalals'
     - run: nix develop --command .github/update-hash replay.deps
     - name: Update PR
       id: update_pr


### PR DESCRIPTION
When renovate creates a PR for a bazel dependency update, we have to update the BCR in order to find the new module.